### PR TITLE
feat: workspace default role name update with variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -213,7 +213,7 @@ data "aws_iam_policy_document" "workspaces" {
 
 resource "aws_iam_role" "workspaces_default" {
   count              = var.enabled ? 1 : 0
-  name               = format("%s-workspaces-role", module.labels.id)
+  name               = var.workspaces_role_name
   assume_role_policy = var.custom_assume_role_policy != null ? var.custom_assume_role_policy : data.aws_iam_policy_document.workspaces.json
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -231,6 +231,13 @@ variable "subnet_ids" {
   description = "List of subnets in VPC"
 }
 
+# This must be set to "workspaces_DefaultRole" as AWS WorkSpaces requires this exact name.
+variable "workspaces_role_name" {
+  description = "The name of the IAM role for AWS WorkSpaces. It must be 'workspaces_DefaultRole' to meet AWS requirements."
+  type        = string
+  default     = "workspaces_DefaultRole"
+}
+
 variable "custom_assume_role_policy" {
   description = "Optional custom assume role policy for WorkSpaces role"
   type        = string


### PR DESCRIPTION
## What

- Created a dedicated variable for the WorkSpaces role name.
- Ensured the role name is exactly workspaces_DefaultRole to comply with AWS WorkSpaces requirements.

## Why

- AWS WorkSpaces requires a role with the exact name workspaces_DefaultRole for directory registration.

## References
[AWS WorkSpaces IAM Role Documentation](https://docs.aws.amazon.com/workspaces/latest/adminguide/workspaces-access-control.html)