### PR TITLE
chore(terraform): adopt Terraform 1.15.0

### DIFF
--- a/.github/workflows/tf-checks.yml
+++ b/.github/workflows/tf-checks.yml
@@ -9,11 +9,14 @@ jobs:
     uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@master
     with:
       working_directory: './examples/AD-Connector/'
+      provider: aws
   Microsoft-AD:
     uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@master
     with:
       working_directory: './examples/Microsoft-AD/'
+      provider: aws
   Simple-AD:
     uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@master
     with:
       working_directory: './examples/Simple-AD/'
+      provider: aws

--- a/examples/AD-Connector/versions.tf
+++ b/examples/AD-Connector/versions.tf
@@ -1,6 +1,6 @@
 # Terraform version
 terraform {
-  required_version = ">= 1.6.6"
+  required_version = ">= 1.15.0"
 
   required_providers {
     aws = {

--- a/examples/Microsoft-AD/versions.tf
+++ b/examples/Microsoft-AD/versions.tf
@@ -1,6 +1,6 @@
 # Terraform version
 terraform {
-  required_version = ">= 1.6.6"
+  required_version = ">= 1.15.0"
 
   required_providers {
     aws = {

--- a/examples/Simple-AD/versions.tf
+++ b/examples/Simple-AD/versions.tf
@@ -1,6 +1,6 @@
 # Terraform version
 terraform {
-  required_version = ">= 1.6.6"
+  required_version = ">= 1.15.0"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 # Terraform version
 terraform {
-  required_version = ">= 1.6.6"
+  required_version = ">= 1.15.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Summary
- Bump Terraform  constraints to ">= 1.15.0".
- Update pinned  workflow inputs to  where present.
- Keep reusable workflows from  intact.

## Validation
- CI will validate formatting, linting, and module checks.

Auto-merge is enabled; branch protection rules will be respected.